### PR TITLE
🐛 fix(transação): corrigir erro no input de valores quebrados #1

### DIFF
--- a/_Sistema/transacao.php
+++ b/_Sistema/transacao.php
@@ -119,7 +119,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <form method="POST">
                 <div class="form-group">
                     <label for="valor">valor</label>
-                    <input type="number" class="form-control" id="valor" name="valor" aria-describedby="Categoria"
+                    <input type="number" class="form-control" id="valor" step="0.010" name="valor" aria-describedby="Categoria"
                         placeholder="valor da Transação">
                     <br>
                     <label for="tipo">Tipo da transação</label>


### PR DESCRIPTION
Corrige erro de input na aplicação. O valor quando era inserido mandava colocar só valor inteiro, adicionado condição para poder inserir valores quebrados também 
Resolve a Issue #1 .
